### PR TITLE
[CI] Add Windows ARM GitHub Build Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,29 @@
-name: Build MSI
+name: Build Installers
 on: [push]
 
 jobs:
   build:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x64
+            runner: windows-latest
+            arch: x86_64
+            args: ''
+            bundle-path: src-tauri/target/release/bundle
+            artifact-name: installer-x64
+
+          - name: arm64
+            runner: windows-11-arm
+            arch: aarch64
+            args: '--bundles nsis'
+            bundle-path: src-tauri/target/release/bundle
+            artifact-name: installer-arm64
+
+    name: Build (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -14,22 +34,33 @@ jobs:
           node-version: lts/*
           cache: 'npm'
 
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install dependencies
         run: npm install
 
-      - name: Build Tauri App (Generates MSI)
+      - name: Build Tauri App
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: v__VERSION__ # This will be auto-replaced
+          tagName: v__VERSION__
           releaseName: "OmniSearch v__VERSION__"
           releaseBody: "Automated build from GitHub Actions"
           releaseDraft: true
           prerelease: false
+          args: ${{ matrix.args }}
 
       - name: Upload MSI Artifact
+        if: matrix.arch == 'x86_64'
         uses: actions/upload-artifact@v4
         with:
-          name: msi-installer
-          path: src-tauri/target/release/bundle/msi/*.msi
+          name: ${{ matrix.artifact-name }}-msi
+          path: ${{ matrix.bundle-path }}/msi/*.msi
+
+      - name: Upload NSIS Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}-nsis
+          path: ${{ matrix.bundle-path }}/nsis/*.exe


### PR DESCRIPTION
Add a native Windows ARM 64 build using the windows-11-arm GitHub-hosted runner to the existing CI workflow.

With the rising popularity of Windows ARM 64 devices, such as the latest Surface / Snapdragon X laptops, and recently released Snapdragon X2 devices and Nvidia N1X SOC users are increasingly expecting native applications.

I tested this on my fork using the NSIS built installer (Tauri's MSI bundler doesn't support ARM64) on my Snapdragon X2 device (Asus Zenbook A16).  